### PR TITLE
[Core] Expose `NapProtoMsg.fields` to be reused

### DIFF
--- a/packages/core/NapProto.ts
+++ b/packages/core/NapProto.ts
@@ -127,7 +127,7 @@ export type NapProtoEncodeStructType<T> = NapProtoStructType<T, true>;
 
 export type NapProtoDecodeStructType<T> = NapProtoStructType<T, false>;
 
-class NapProtoRealMsg<T extends ProtoMessageType> {
+class NapProtoRealMsg<const T extends ProtoMessageType> {
     private readonly _field: PartialFieldInfo[];
     private readonly _proto_msg: MessageType<NapProtoStructType<T, boolean>>;
     private static cache = new WeakMap<ProtoMessageType, NapProtoRealMsg<any>>();
@@ -180,10 +180,10 @@ class NapProtoRealMsg<T extends ProtoMessageType> {
     }
 }
 
-export class NapProtoMsg<T extends ProtoMessageType> {
+export class NapProtoMsg<const T extends ProtoMessageType> {
     private realMsg: NapProtoRealMsg<T>;
 
-    constructor(fields: T) {
+    constructor(public fields: T) {
         this.realMsg = NapProtoRealMsg.getInstance(fields);
     }
 


### PR DESCRIPTION
Formally, when defining nesting messages using `ProtoField`, we could only specify the nested type directly in the nesting type like this:
```ts
const B = new NapProtoMsg({
  foo: ProtoField(1, () => ({               //
    bar: ProtoField(1, ScalarType.UINT32),  // We want to take this out as A
  })),                                      //
});
```

But sometimes we want to reuse a pre-defined type. Now, the `fields` in `NapProtoMsg` is exposed as a literal type from what is passed in the constructor, so we can define a nesting message `B` from `A` like this:
```ts
const A = new NapProtoMsg({
  bar: ProtoField(1, ScalarType.UINT32),
});

const B = new NapProtoMsg({
  foo: ProtoField(1, () => A.fields),
});
```

## Summary by Sourcery

新特性：
- 在使用 `ProtoField` 定义嵌套消息时，重用字段定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Reuse field definitions when defining nested messages using `ProtoField`.

</details>