### PR TITLE
[Core] Make `nap-proto-core` able to be imported directly

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@napneko/nap-proto-core",
+  "type": "module",
   "version": "0.0.5",
   "description": "A lightweight, elegant, and efficient protobuf-ts solution",
   "main": "dist/NapProto.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,9 +2,11 @@
   "name": "@napneko/nap-proto-core",
   "version": "0.0.5",
   "description": "A lightweight, elegant, and efficient protobuf-ts solution",
-  "main": "NapProto.ts",
+  "main": "dist/NapProto.js",
+  "types": "dist/NapProto.d.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepack": "tsc"
   },
   "dependencies": {
     "@protobuf-ts/runtime": "^2.9.4"

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "outDir": "dist",
     "declaration": true,
-    "declarationDir": "dist/types",
+    "declarationDir": "dist",
     "sourceMap": true
   },
   "include": [


### PR DESCRIPTION
Formally `nap-proto-core` directly published source code, which is in TypeScript, to NPM registry, making it unable to be called without bundling. Now with `type: module` and `prepack` script added, there is no need to compile the package manually and all work is done before packing.

## Summary by Sourcery

构建:
- 在打包之前，使用 TypeScript 编译器预构建 `nap-proto-core`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Pre-build `nap-proto-core` using TypeScript compiler before packaging.

</details>