### PR TITLE
[Core] Export all interfaces in NapProto.ts

### DIFF
--- a/packages/core/NapProto.ts
+++ b/packages/core/NapProto.ts
@@ -1,9 +1,9 @@
 import { MessageType, PartialMessage, RepeatType, ScalarType } from '@protobuf-ts/runtime';
 import { PartialFieldInfo } from '@protobuf-ts/runtime/build/types/reflection-info';
 
-type LowerCamelCase<S extends string> = CamelCaseHelper<S, false, true>;
+export type LowerCamelCase<S extends string> = CamelCaseHelper<S, false, true>;
 
-type CamelCaseHelper<
+export type CamelCaseHelper<
     S extends string,
     CapNext extends boolean,
     IsFirstChar extends boolean,
@@ -19,7 +19,7 @@ type CamelCaseHelper<
               : `${F}${CamelCaseHelper<R, false, false>}`
     : '';
 
-type ScalarTypeToTsType<T extends ScalarType> = T extends
+export type ScalarTypeToTsType<T extends ScalarType> = T extends
     | ScalarType.DOUBLE
     | ScalarType.FLOAT
     | ScalarType.INT32
@@ -38,7 +38,7 @@ type ScalarTypeToTsType<T extends ScalarType> = T extends
             ? Uint8Array
             : never;
 
-interface BaseProtoFieldType<T, O extends boolean, R extends O extends true ? false : boolean> {
+export interface BaseProtoFieldType<T, O extends boolean, R extends O extends true ? false : boolean> {
     kind: 'scalar' | 'message';
     no: number;
     type: T;
@@ -59,11 +59,11 @@ export interface MessageProtoFieldType<
     kind: 'message';
 }
 
-type ProtoFieldType =
+export type ProtoFieldType =
     | ScalarProtoFieldType<ScalarType, boolean, boolean>
     | MessageProtoFieldType<() => ProtoMessageType, boolean, boolean>;
 
-type ProtoMessageType = {
+export type ProtoMessageType = {
     [key: string]: ProtoFieldType;
 };
 
@@ -90,14 +90,14 @@ export function ProtoField(
     }
 }
 
-type ProtoFieldReturnType<T, E extends boolean> =
+export type ProtoFieldReturnType<T, E extends boolean> =
     NonNullable<T> extends ScalarProtoFieldType<infer S, infer O, infer R>
         ? ScalarTypeToTsType<S>
         : T extends NonNullable<MessageProtoFieldType<infer S, infer O, infer R>>
           ? NonNullable<NapProtoStructType<ReturnType<S>, E>>
           : never;
 
-type RequiredFieldsBaseType<T, E extends boolean> = {
+export type RequiredFieldsBaseType<T, E extends boolean> = {
     [K in keyof T as T[K] extends { optional: true } ? never : LowerCamelCase<K & string>]: T[K] extends {
         repeat: true;
     }
@@ -105,7 +105,7 @@ type RequiredFieldsBaseType<T, E extends boolean> = {
         : ProtoFieldReturnType<T[K], E>;
 };
 
-type OptionalFieldsBaseType<T, E extends boolean> = {
+export type OptionalFieldsBaseType<T, E extends boolean> = {
     [K in keyof T as T[K] extends { optional: true } ? LowerCamelCase<K & string> : never]?: T[K] extends {
         repeat: true;
     }
@@ -113,15 +113,15 @@ type OptionalFieldsBaseType<T, E extends boolean> = {
         : ProtoFieldReturnType<T[K], E>;
 };
 
-type RequiredFieldsType<T, E extends boolean> = E extends true
+export type RequiredFieldsType<T, E extends boolean> = E extends true
     ? Partial<RequiredFieldsBaseType<T, E>>
     : RequiredFieldsBaseType<T, E>;
 
-type OptionalFieldsType<T, E extends boolean> = E extends true
+export type OptionalFieldsType<T, E extends boolean> = E extends true
     ? Partial<OptionalFieldsBaseType<T, E>>
     : OptionalFieldsBaseType<T, E>;
 
-type NapProtoStructType<T, E extends boolean> = RequiredFieldsType<T, E> & OptionalFieldsType<T, E>;
+export type NapProtoStructType<T, E extends boolean> = RequiredFieldsType<T, E> & OptionalFieldsType<T, E>;
 
 export type NapProtoEncodeStructType<T> = NapProtoStructType<T, true>;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@napneko/nap-proto-core",
   "type": "module",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A lightweight, elegant, and efficient protobuf-ts solution",
   "main": "dist/NapProto.js",
   "types": "dist/NapProto.d.ts",


### PR DESCRIPTION
鬼知道什么时候会用到这些东西
<img width="885" alt="image" src="https://github.com/user-attachments/assets/9e6d48ca-fb84-4483-a004-bff729431c1c" />

顺便 Bump 了一下版本到 0.0.6（已经发布的，不知道为啥没 commit

这次别忘了 Bump 到 0.0.7

## Summary by Sourcery

Chores:
- 将版本升级到 0.0.6。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Chores:
- Bump version to 0.0.6.

</details>