### PR TITLE
[Core] Create snapshot and load lazily

### DIFF
--- a/packages/core/NapProto.ts
+++ b/packages/core/NapProto.ts
@@ -84,7 +84,13 @@ export function ProtoField(
     repeat?: boolean
 ): ProtoFieldType {
     if (typeof type === 'function') {
-        return { kind: 'message', no: no, type: type, optional: optional ?? false, repeat: repeat ?? false };
+        let snapshot: ProtoMessageType | undefined;
+        return { kind: 'message', no: no, type: () => {
+            if (!snapshot) {
+                snapshot = type();
+            }
+            return snapshot;
+        }, optional: optional ?? false, repeat: repeat ?? false };
     } else {
         return { kind: 'scalar', no: no, type: type, optional: optional ?? false, repeat: repeat ?? false };
     }


### PR DESCRIPTION
众所周知，proto 文件中的 message 是扁平化的，如果要嵌套，必须在并列的位置声明一个新的 message 然后引用，例如：
```proto
message Outer {
  Inner inner = 1;
}

message Inner {
  string foo = 1;
}
```
在 NapProto 中对应的写法是：
```ts
const Outer = new NapProtoMsg({
  inner: ProtoField(1, () => Inner.fields),
});

const Inner = new NapProtoMsg({
  foo: ProtoField(1, ScalarType.STRING),
});
```
按照 proto 的标准写法，每个 message 都对应**一个** NapProtoMsg 对象，因此可以直接通过 Supplier 提供 Inner 对象。

但 NapProto 同时又支持这样的写法：
```ts
const Outer = new NapProtoMsg({
  inner: ProtoField(1, () => ({
    foo: ProtoField(1, ScalarType.STRING),
  })),
});
```
这种写法无需声明 message，但却带来了潜在的效率问题：由于 TypeScript 不支持类型的递归引用，因此嵌套 type 必须有 Supplier 方法。这样，每次序列化或反序列化，需要获取 message 声明，而每次获取都会创建一个 `{ foo: ProtoField(1, ScalarType.STRING) }` 对象，当 message 非常庞大的时候，这就带来了极大的开销。

因此，在 ProtoField 接收一个 Supplier 函数的位置，进行了如下优化：预留一个用于保存 message 声明引用的位置，当**第一次**获取这个声明时，调用原本的 Supplier 方法，将调用结果存储到这一位置，后续调用不再需要原先的方法。

这一方法对于上面的标准写法而言没有什么内存开销，只是多了一个对外部 NapProtoMsg 的引用；而对于“懒人”写法，则无论进行多少次序列化，都只会创建一次对象，大大降低了时间开销。

这一写法已经在我的项目 tanebi 中测试过，并无问题。

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

优化 NapProto 中消息声明的延迟加载，以减少序列化和反序列化期间的性能开销

新特性：
- 增加消息类型声明的延迟初始化和记忆化，以提高性能

增强功能：
- 实施消息声明的快照机制，用于缓存和重用消息类型定义，从而消除序列化期间重复的对象创建

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize lazy loading of message declarations in NapProto to reduce performance overhead during serialization and deserialization

New Features:
- Add lazy initialization for message type declarations with memoization to improve performance

Enhancements:
- Implement a snapshot mechanism for message declarations to cache and reuse message type definitions, eliminating repeated object creation during serialization

</details>